### PR TITLE
Add dependency on kramdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@
 gem "sinatra"
 gem "sinatra-cors"
 gem "nokogiri"
+gem "kramdown"
 
 gem "fog-google"
 gem "fog-local"


### PR DESCRIPTION
Turns out for some reason it doesn't pick up automatically so it was necessary to `require` kramdown first.

> Some languages have multiple implementations. To specify what implementation to use (and to be thread-safe), you should simply require it first

(source http://sinatrarb.com/intro.html)